### PR TITLE
Improving resiliancy if no COG available

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -33,7 +33,9 @@ if (self.mmsi) {
     vesselId = `${self.uuid}`;
 }
 
-cog = self.navigation.courseOverGroundTrue.value * 180 / Math.PI;
+cog = self?.navigation?.courseOverGroundTrue?.value !== undefined
+  ? self.navigation.courseOverGroundTrue.value * 180 / Math.PI
+  : 0;
 
 const options = {
     key: key ? key : BUNDLED_WINDY_COM_KEY,


### PR DESCRIPTION
Plugin will fail to load if COG is not available.  This fix allows it to start.